### PR TITLE
Kubernetes csi

### DIFF
--- a/kubernetes-csi/README.md
+++ b/kubernetes-csi/README.md
@@ -1,0 +1,41 @@
+
+# Выполнено ДЗ №12 Установка и использование CSI драйвера
+
+- [x] Основное ДЗ
+
+## В процессе сделано:
+- Установлен и сконфигурирован CSI driver для Yandex Object Storage.
+- Запустил и использовал полезную нагрузку, использующую для хранения бакет в Yandex Object Storage.
+## Как запустить проект:
+- Установить csi драйвер конфигурацию для него в secret.yaml и storageClass
+```shell
+kubectl create -f secret.yaml && \
+kubectl create -f https://raw.githubusercontent.com/yandex-cloud/k8s-csi-s3/refs/heads/master/deploy/kubernetes/provisioner.yaml && \
+kubectl create -f https://raw.githubusercontent.com/yandex-cloud/k8s-csi-s3/refs/heads/master/deploy/kubernetes/driver.yaml && \
+kubectl create -f https://raw.githubusercontent.com/yandex-cloud/k8s-csi-s3/refs/heads/master/deploy/kubernetes/csi-s3.yaml && \
+kubectl create -f storageclass.yaml
+```
+ - Установить полезную нагрузку.
+```shell
+kubectl apply -f pvc.yaml -f deployment.yaml
+```
+
+## Как проверить работоспособность:
+- Проверить что поды создают файлы в /data
+```shell
+ kubectl exec -ti example-csi-6b64d676cc-59lmg -- ls -la /data
+total 14
+drwxrwxrwx    2 root     root          4096 Feb  2 18:32 .
+drwxr-xr-x    1 root     root          4096 Feb  2 18:32 ..
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521137.txt
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521138.txt
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521142.txt
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521143.txt
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521147.txt
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521148.txt
+-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521152.txt
+```
+
+## PR checklist:
+- [ ] Выставлен label с темой домашнего задания
+

--- a/kubernetes-csi/README.md
+++ b/kubernetes-csi/README.md
@@ -35,6 +35,7 @@ drwxr-xr-x    1 root     root          4096 Feb  2 18:32 ..
 -rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521148.txt
 -rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521152.txt
 ```
+ - Проверить что в Yandex Object Storage есть файлы из предыдущего пункта. 
 
 ## PR checklist:
 - [ ] Выставлен label с темой домашнего задания

--- a/kubernetes-csi/deployment.yaml
+++ b/kubernetes-csi/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-csi
+  namespace: default
+  labels: &labels
+    app: example-csi
+spec:
+  replicas: 3
+  selector:
+    matchLabels: *labels
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      containers:
+        - name: writer
+          image: perovmpr/file-writer:0.0.1
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: csi-s3-pvc

--- a/kubernetes-csi/pvc.yaml
+++ b/kubernetes-csi/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-s3-pvc
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: csi-s3

--- a/kubernetes-csi/secret.yaml
+++ b/kubernetes-csi/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: kube-system
+  name: csi-s3-secret
+stringData:
+  accessKeyID: *******************
+  secretAccessKey: *******************
+  endpoint: https://storage.yandexcloud.net

--- a/kubernetes-csi/storageclass.yaml
+++ b/kubernetes-csi/storageclass.yaml
@@ -1,0 +1,18 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: csi-s3
+provisioner: ru.yandex.s3.csi
+parameters:
+  mounter: geesefs
+  options: "--memory-limit=1000 --dir-mode=0777 --file-mode=0666"
+  bucket: csi-s3-pvc1
+  csi.storage.k8s.io/provisioner-secret-name: csi-s3-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-publish-secret-name: csi-s3-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+  csi.storage.k8s.io/node-publish-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: kube-system


### PR DESCRIPTION

# Выполнено ДЗ №12 Установка и использование CSI драйвера

- [x] Основное ДЗ

## В процессе сделано:
- Установлен и сконфигурирован CSI driver для Yandex Object Storage.
- Запустил и использовал полезную нагрузку, использующую для хранения бакет в Yandex Object Storage.
## Как запустить проект:
- Установить csi драйвер конфигурацию для него в secret.yaml и storageClass
```shell
kubectl create -f secret.yaml && \
kubectl create -f https://raw.githubusercontent.com/yandex-cloud/k8s-csi-s3/refs/heads/master/deploy/kubernetes/provisioner.yaml && \
kubectl create -f https://raw.githubusercontent.com/yandex-cloud/k8s-csi-s3/refs/heads/master/deploy/kubernetes/driver.yaml && \
kubectl create -f https://raw.githubusercontent.com/yandex-cloud/k8s-csi-s3/refs/heads/master/deploy/kubernetes/csi-s3.yaml && \
kubectl create -f storageclass.yaml
```
 - Установить полезную нагрузку.
```shell
kubectl apply -f pvc.yaml -f deployment.yaml
```

## Как проверить работоспособность:
- Проверить что поды создают файлы в /data
```shell
 kubectl exec -ti example-csi-6b64d676cc-59lmg -- ls -la /data
total 14
drwxrwxrwx    2 root     root          4096 Feb  2 18:32 .
drwxr-xr-x    1 root     root          4096 Feb  2 18:32 ..
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521137.txt
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521138.txt
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521142.txt
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521143.txt
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521147.txt
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521148.txt
-rw-rw-rw-    1 root     root            61 Feb  2 18:32 file_1738521152.txt
```
 - Проверить что в Yandex Object Storage есть файлы из предыдущего пункта. Файлы есть

## PR checklist:
- [ ] Выставлен label с темой домашнего задания

